### PR TITLE
将CFocusManager::ClearFocus改成public,控件调用这个方法来清除焦点。

### DIFF
--- a/SOUI/include/core/FocusManager.h
+++ b/SOUI/include/core/FocusManager.h
@@ -136,12 +136,13 @@ namespace SOUI
         // a reason). If the focus change should only happen if the view is
         // currenty focusable, enabled, and visible, call view->RequestFocus().
         void SetFocusedHwndWithReason(SWND swnd, FocusChangeReason reason);
-        void SetFocusedHwnd(SWND swnd)
-        {
-            SetFocusedHwndWithReason(swnd, kReasonDirectFocusChange);
-        }
+		void SetFocusedHwnd(SWND swnd);
 
-        SWND GetFocusedHwnd(){return focused_view_;}
+		// Clears the focused view. The window associated with the top root view gets
+		// the native focus (so we still get keyboard events).
+		void ClearFocus();
+
+		SWND GetFocusedHwnd();
 
         // Stores and restores the focused view. Used when the window becomes
         // active/inactive.
@@ -181,10 +182,6 @@ namespace SOUI
     private:
         // Returns the next focusable view.
         SWindow * GetNextFocusableView(SWindow* pWndStarting, bool bReverse, bool bLoop);
-
-        // Clears the focused view. The window associated with the top root view gets
-        // the native focus (so we still get keyboard events).
-        void ClearFocus();
 
         // Validates the focused view, clearing it if the window it belongs too is not
         // attached to the window hierarchy anymore.

--- a/SOUI/src/control/SListView.cpp
+++ b/SOUI/src/control/SListView.cpp
@@ -368,7 +368,7 @@ namespace SOUI
             if(ii.pItem->GetState() & WndState_Check)
             {
                 ii.pItem->ModifyItemState(0,WndState_Check);
-                ii.pItem->GetFocusManager()->SetFocusedHwnd(0);
+                ii.pItem->GetFocusManager()->ClearFocus();
             }
             ii.pItem->SetVisible(FALSE);
             ii.pItem->GetEventSet()->setMutedState(false);
@@ -804,7 +804,7 @@ namespace SOUI
         SItemPanel *pItem = GetItemPanel(nOldSel);
         if(pItem)
         {
-            pItem->GetFocusManager()->SetFocusedHwnd((SWND)-1);
+            pItem->GetFocusManager()->ClearFocus();
             pItem->ModifyItemState(0,WndState_Check);
             RedrawItem(pItem);
         }

--- a/SOUI/src/control/SMCListView.cpp
+++ b/SOUI/src/control/SMCListView.cpp
@@ -639,7 +639,7 @@ void SMCListView::UpdateVisibleItems()
         if(ii.pItem->GetState() & WndState_Check)
         {
             ii.pItem->ModifyItemState(0,WndState_Check);
-            ii.pItem->GetFocusManager()->SetFocusedHwnd(0);
+            ii.pItem->GetFocusManager()->ClearFocus();
         }
         ii.pItem->SetVisible(FALSE);
         ii.pItem->GetEventSet()->setMutedState(false);
@@ -1073,7 +1073,7 @@ void SMCListView::SetSel(int iItem,BOOL bNotify)
     SItemPanel *pItem = GetItemPanel(nOldSel);
     if(pItem)
     {
-        pItem->GetFocusManager()->SetFocusedHwnd((SWND)-1);
+        pItem->GetFocusManager()->ClearFocus();
         pItem->ModifyItemState(0,WndState_Check);
         RedrawItem(pItem);
     }

--- a/SOUI/src/control/STileView.cpp
+++ b/SOUI/src/control/STileView.cpp
@@ -378,7 +378,7 @@ void STileView::UpdateVisibleItems()
         if(ii.pItem->GetState() & WndState_Check)
         {
             ii.pItem->ModifyItemState(0, WndState_Check);
-            ii.pItem->GetFocusManager()->SetFocusedHwnd(0);
+            ii.pItem->GetFocusManager()->ClearFocus();
         }
         ii.pItem->SetVisible(FALSE);
         ii.pItem->GetEventSet()->setMutedState(false);
@@ -813,7 +813,7 @@ void STileView::SetSel(int iItem, BOOL bNotify)
     SItemPanel *pItem = GetItemPanel(nOldSel);
     if(pItem)
     {
-        pItem->GetFocusManager()->SetFocusedHwnd((SWND)-1);
+        pItem->GetFocusManager()->ClearFocus();
         pItem->ModifyItemState(0, WndState_Check);
         RedrawItem(pItem);
     }

--- a/SOUI/src/control/STreeView.cpp
+++ b/SOUI/src/control/STreeView.cpp
@@ -599,7 +599,7 @@ namespace SOUI
         SItemPanel *pItem = GetItemPanel(m_hSelected);
         if(pItem)
         {
-            pItem->GetFocusManager()->SetFocusedHwnd((SWND)-1);
+            pItem->GetFocusManager()->ClearFocus();
             pItem->ModifyItemState(0,WndState_Check);
             RedrawItem(pItem);
         }
@@ -879,7 +879,7 @@ namespace SOUI
             if((HTREEITEM)ii.pItem->GetItemIndex() == m_hSelected)
             {
                 ii.pItem->ModifyItemState(0, WndState_Check);
-                ii.pItem->GetFocusManager()->SetFocusedHwnd(0);
+                ii.pItem->GetFocusManager()->ClearFocus();
             }
             ii.pItem->SetVisible(FALSE);//防止执行SItemPanel::OnTimeFrame()
             ii.pItem->GetEventSet()->setMutedState(false);

--- a/SOUI/src/core/FocusManager.cpp
+++ b/SOUI/src/core/FocusManager.cpp
@@ -276,6 +276,10 @@ namespace SOUI
     {
         if(swnd == focused_view_)
         {
+			if (swnd == 0 && focused_backup_)
+			{//clear focus
+				focused_backup_ = swnd;
+			}
             return;
         }
         
@@ -304,6 +308,11 @@ namespace SOUI
         }
     }
 
+	void CFocusManager::SetFocusedHwnd(SWND swnd)
+	{
+		SetFocusedHwndWithReason(swnd, kReasonDirectFocusChange);
+	}
+
     void CFocusManager::ValidateFocusedView()
     {
         if(focused_view_)
@@ -325,8 +334,10 @@ namespace SOUI
 
     void CFocusManager::ClearFocus()
     {
-        SetFocusedHwnd(NULL);
+        SetFocusedHwnd(0);
     }
+
+	SWND CFocusManager::GetFocusedHwnd() { return focused_view_; }
 
     void CFocusManager::StoreFocusedView()
     {


### PR DESCRIPTION
解决在CFocusManager::StoreFocusedView状态下清除焦点失败的BUG。